### PR TITLE
将int64反序列为Long类型的对象

### DIFF
--- a/weichatPb/src/longBits.js
+++ b/weichatPb/src/longBits.js
@@ -1,5 +1,6 @@
 module.exports = LongBits;
 
+var  util = require('./util');
 function LongBits(lo, hi) {
     this.lo = lo >>> 0;
     this.hi = hi >>> 0;
@@ -55,11 +56,11 @@ LongBits.prototype.toNumber = function toNumber(unsigned) {
     return this.lo + this.hi * 4294967296;
 };
 LongBits.prototype.toLong = function toLong(unsigned) {
-    //return util.Long
-    //    ? new util.Long(this.lo | 0, this.hi | 0, Boolean(unsigned))
-    //    /* istanbul ignore next */
-    //    : { low: this.lo | 0, high: this.hi | 0, unsigned: Boolean(unsigned) };
-    return { low: this.lo | 0, high: this.hi | 0, unsigned: Boolean(unsigned) };
+    return util.Long
+       ? new util.Long(this.lo | 0, this.hi | 0, Boolean(unsigned))
+       /* istanbul ignore next */
+       : { low: this.lo | 0, high: this.hi | 0, unsigned: Boolean(unsigned) };
+    // return { low: this.lo | 0, high: this.hi | 0, unsigned: Boolean(unsigned) };
 };
 
 var charCodeAt = String.prototype.charCodeAt;


### PR DESCRIPTION
反序列int64时，转成Long类型的对象更方便使用。

-------

原始代码，将对应代码注释了，请问是基于什么考虑的？