### PR TITLE
修复 枚举 类型检验判断 不正确

### DIFF
--- a/weichatPb/src/verifier.js
+++ b/weichatPb/src/verifier.js
@@ -15,7 +15,7 @@ function verifyValue(field, fieldIndex, ref, options){
     if(field.resolvedType){
         if(field.resolvedType instanceof Enum){
             var keys = Object.keys(field.resolvedType.values);
-            if (keys.indexOf(ref)<0){
+            if (keys[ref] === undefined){
                 //没有找到时候
                 return invalid(field, "enum value");
             }


### PR DESCRIPTION
修复 bug：
枚举 类型检验判断 不正确，导致抛出 enum value expected 的 error 信息。